### PR TITLE
Improve "Total PPE Delivered" component

### DIFF
--- a/components/deliveries.jsx
+++ b/components/deliveries.jsx
@@ -1,4 +1,5 @@
 import totals from './totals'
+import { isToday, parse, formatDistanceStrict, startOfToday } from 'date-fns'
 
 export let totalCount = 0
 
@@ -18,7 +19,7 @@ export default ({ limit }) => {
     <div className={'bg-white sm:rounded-md p-4 h-full hover:no-underline'}>
       <a
         href="/stats"
-        className="rounded-lg inline-block w-full hover:no-underline"
+        className="rounded-lg inline-block w-full hover:no-underline "
       >
         <span className="flex justify-between ">
           <p className="text-xl leading-6 font-medium text-gray-900  hover:no-underline">
@@ -44,7 +45,8 @@ export default ({ limit }) => {
       {!limit && (
         <>
           <p className="pt-12 text-xl leading-6 font-medium text-gray-900  hover:no-underline">
-            Latest
+            Latest PPE deliveries. Only locations are given. We deliver PPE to
+            EMTs, nursing homes, and hospitals.
           </p>{' '}
           <table className="w-full table border-transparent">
             <tbody className="w-full table border-none">
@@ -81,7 +83,13 @@ export default ({ limit }) => {
                       />
                     </svg>
                     <span>
-                      <time dateTime="2020-01-07">{props.date}</time>
+                      {isToday(parse(props.date, 'MM/dd/yyyy', new Date()))
+                        ? 'Today'
+                        : formatDistanceStrict(
+                            parse(props.date, 'MM/dd/yyyy', new Date()),
+                            startOfToday(),
+                            { unit: 'day', addSuffix: 'true' }
+                          )}
                     </span>
                   </td>
                 </tr>

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@tailwindcss/ui": "^0.1.3",
     "axios": "^0.19.2",
     "cheerio": "^1.0.0-rc.3",
+    "date-fns": "^2.11.1",
     "next": "^9.2.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2521,6 +2521,11 @@ d@1, d@^1.0.1:
     es5-ext "^0.10.50"
     type "^1.0.1"
 
+date-fns@^2.11.1:
+  version "2.11.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.11.1.tgz#197b8be1bbf5c5e6fe8bea817f0fe111820e7a12"
+  integrity sha512-3RdUoinZ43URd2MJcquzBbDQo+J87cSzB8NkXdZiN5ia1UNyep0oCyitfiL88+R7clGTeq/RniXAc16gWyAu1w==
+
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"


### PR DESCRIPTION
- [x] Just say "Face Shield" instead of specific design (https://github.com/NYCPPE/nyc-makers-vs-covid/commit/cd63a8958d3a62b9d760f7c93350e23c088482f1)
- [x] Text above the table to explain we can't disclose specific hospitals, but that these are hospitals, nursing homes, and EMTs
- [x] Need a header row on the table
- [x] Consider date delta (1 days ago, etc.)


Closes #24