### PR TITLE
Move press coverage to its own page 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ This project comes with tailwindcss to make styling faster. It also includes the
 
 Sometimes formatting gets off but fear not we have added a script -- simply run `yarn format` and it will format any code that you have modified to our consistent style.
 
-There is a .prettierrc file which specifies the configuration for [prettier](https://prettier.io/). We use another package, [pretty-quick](https://github.com/azz/pretty-quick#readme) to run thr formatter on files you've modified.
+There is a .prettierrc file which specifies the configuration for [prettier](https://prettier.io/). We use another package, [pretty-quick](https://github.com/azz/pretty-quick#readme) to run the formatter on files you've modified.

--- a/components/footer.jsx
+++ b/components/footer.jsx
@@ -13,7 +13,7 @@ export default ({ children }) => (
 
         <div className="px-5 py-2">
           <a
-            href="mailto:jake.h.lee@columbia.edu"
+            href="/press"
             className="text-base leading-6 text-gray-500 hover:text-gray-900"
           >
             Press

--- a/components/media.jsx
+++ b/components/media.jsx
@@ -45,6 +45,15 @@ export default () => (
           {organization} - {date}
         </a>
       ))}
+      <div className="mt-12 mb-2 py-2 px-4 text-center text-2xl font-bold text-gray-900">
+        For media inquires contact us at{' '}
+        <a
+          href="mailto:mediainfo@nycmakesppe.com"
+          className="block w-full rounded-lg over:bg-gray-100 text-pink-600 overflow-hidden flex flex-col justify-between px-4 py-2"
+        >
+          mediainfo@nycmakesppe.com
+        </a>
+      </div>
     </div>
   </>
 )

--- a/components/nav.jsx
+++ b/components/nav.jsx
@@ -14,6 +14,7 @@ const links = [
     label: 'Request'
   },
   { href: '/stats', label: 'Stats', hide: true },
+  { href: '/press', label: 'Press' },
   { href: '/about', label: 'About' }
 ]
 

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -103,13 +103,12 @@ export default () => (
       </a>
       <a
         className="text-base text-pink-600 rounded-lg"
-        href="mailto:jake.h.lee@columbia.edu"
+        href="mailto:nycmakesppe@nycmakesppe.com"
       >
         Get involved
       </a>
     </div>
 
-    <Media />
     <div className="mt-12 mb-4 px-4 text-xl font-bold text-gray-900">
       Find us online
     </div>

--- a/pages/instructions.mdx
+++ b/pages/instructions.mdx
@@ -80,7 +80,7 @@ Instructions are available here: [\[External Link\]](https://www.project-cloth-m
 ### DIY Paper Mask
 
 [[warning]]
-| This design has not yet been tested - please [reach out](mailto:jake.h.lee@columbia.edu) if you're interested in giving feeback.
+| This design has not yet been tested - please [reach out](mailto:nycmakesppe@nycmakesppe.com) if you're interested in giving feeback.
 
 This mask concept can be assembled in about 10 minutes using a piece paper. Designed for the general public to avoid using supply that might be needed by hospitals or those who can't otherwise get access to other masks. Instructions are available here: [\[Internal Link\]](/pdf/Face_Mask_DIY_V2.4_JP_Leconte_PaperPaul.pdf)
 

--- a/pages/press.jsx
+++ b/pages/press.jsx
@@ -1,0 +1,9 @@
+import Media from '../components/media'
+
+export default () => {
+  return (
+    <>
+      <Media />
+    </>
+  )
+}


### PR DESCRIPTION
- Make media a /press page with our media coverage and a link to mediainfo@ at bottom
- use nycmakesppe@gmail as opposed to Jake's
- Link to press in header, as well as footer
- typo fixes otherwise
